### PR TITLE
Add initial 2019 chapter survey analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_Store
 .idea
-.csv
+*.csv
+.ipynb_checkpoints

--- a/surveys/2019/chapter_organizers/Analysis.ipynb
+++ b/surveys/2019/chapter_organizers/Analysis.ipynb
@@ -1,0 +1,836 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 438,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import requests\n",
+    "import datapackage\n",
+    "import pycountry_convert as pc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 439,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(66, 7)"
+      ]
+     },
+     "execution_count": 439,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv('pyladies_chapter_leaders_survey.csv') #, index_col=0)\n",
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 440,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['Timestamp', 'Which PyLadies chapter do you belong to?',\n",
+       "       'When was your last event?',\n",
+       "       'What are the challenges your chapter has faced?',\n",
+       "       'How can the PyLadies leadership team help you run your chapter better?',\n",
+       "       'email', 'Email Address'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 440,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 441,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.rename(columns={\n",
+    "    'Timestamp': 'timestampe', \n",
+    "    'Which PyLadies chapter do you belong to?': 'name',\n",
+    "    'When was your last event?': 'last_event',\n",
+    "    'What are the challenges your chapter has faced?': 'challenges',\n",
+    "    'How can the PyLadies leadership team help you run your chapter better?': 'improvement',\n",
+    "    'email': 'intended_individual_email', \n",
+    "    'Email Address':'intended_chapter_email'\n",
+    "}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 442,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['timestampe', 'name', 'last_event', 'challenges', 'improvement',\n",
+       "       'intended_individual_email', 'intended_chapter_email'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 442,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 443,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_responses = df.name.count()\n",
+    "num_chapters = df.name.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 444,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0                                       Brisbane\n",
+       "1                               PyLadies Nigeria\n",
+       "2                               PyLadies Hamburg\n",
+       "3                                      Wellesley\n",
+       "4                                PyLadies London\n",
+       "5                                         London\n",
+       "6                                          Miami\n",
+       "7                                       Brasilia\n",
+       "8                           Pyladies Addis Ababa\n",
+       "9                                  San Francisco\n",
+       "10                               Pyladies London\n",
+       "11                                     Vancouver\n",
+       "12                              Oakland PyLadies\n",
+       "13                               Pyladies La Paz\n",
+       "14                                       Seattle\n",
+       "15                                     Fortaleza\n",
+       "16                                     Melbourne\n",
+       "17                                       Effurun\n",
+       "18                                       Chicago\n",
+       "19                                Chennai, India\n",
+       "20                                        Newark\n",
+       "21                                   Mexico City\n",
+       "22                              PyLadies Okinawa\n",
+       "23                              Grand Rapids, MI\n",
+       "24                                  NorthWest UK\n",
+       "25                                    Central PA\n",
+       "26                              Campinas, Brazil\n",
+       "27                          Pyladies Bhubaneswar\n",
+       "28                                          Lima\n",
+       "29                             PyLadies Arequipa\n",
+       "                         ...                    \n",
+       "36                        Santa Cruz, California\n",
+       "37                             Sydney, Australia\n",
+       "38                             PyLadies São Luís\n",
+       "39                                Salt Lake City\n",
+       "40                    Amsterdam, the Netherlands\n",
+       "41                              PyLadies Goiânia\n",
+       "42                                  Goa Pyladies\n",
+       "43                                       Bangkok\n",
+       "44                                        Dublin\n",
+       "45                                        Recife\n",
+       "46                                       Houston\n",
+       "47                                        Recife\n",
+       "48                                 Paris, France\n",
+       "49                                     São Paulo\n",
+       "50                              Pyladies Kampala\n",
+       "51    Rural Federal University of Rio de Janeiro\n",
+       "52                              Teresina, Brazil\n",
+       "53                                       Paraiba\n",
+       "54                                        Maceió\n",
+       "55                       PyLadies Recife, Brazil\n",
+       "56                                PyLadies Belém\n",
+       "57                               PyLadies Madrid\n",
+       "58                                         Natal\n",
+       "59                                    São Carlos\n",
+       "60                            PyLadies Vancouver\n",
+       "61                               PyLadies Manaus\n",
+       "62                               PyLadies Brazil\n",
+       "63                                PyLadies Natal\n",
+       "64                                 New York City\n",
+       "65                                        Madrid\n",
+       "Name: name, Length: 66, dtype: object"
+      ]
+     },
+     "execution_count": 444,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 445,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total number of responses: 66\n",
+      "Total number of chapters: 65\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Total number of responses: {num_responses}\\nTotal number of chapters: {num_chapters}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 446,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def standardize_chapter_name(text):\n",
+    "    if ',' in text:\n",
+    "        text = text.split(',')\n",
+    "        text = ' ' .join(word.capitalize() for word in text[0:-1])\n",
+    "    if 'pyladies' in text.lower().split(' '):\n",
+    "        text = text.lower().split(' ')\n",
+    "        text.remove('pyladies')\n",
+    "        if len(text) == 1:\n",
+    "            return text[0].capitalize()\n",
+    "        return ' ' .join(word.capitalize() for word in text)\n",
+    "    \n",
+    "    return text.lower().title()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 447,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(66, 7)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0                                       Brisbane\n",
+       "1                                        Nigeria\n",
+       "2                                        Hamburg\n",
+       "3                                      Wellesley\n",
+       "4                                         London\n",
+       "5                                         London\n",
+       "6                                          Miami\n",
+       "7                                       Brasilia\n",
+       "8                                    Addis Ababa\n",
+       "9                                  San Francisco\n",
+       "10                                        London\n",
+       "11                                     Vancouver\n",
+       "12                                       Oakland\n",
+       "13                                        La Paz\n",
+       "14                                       Seattle\n",
+       "15                                     Fortaleza\n",
+       "16                                     Melbourne\n",
+       "17                                       Effurun\n",
+       "18                                       Chicago\n",
+       "19                                       Chennai\n",
+       "20                                        Newark\n",
+       "21                                   Mexico City\n",
+       "22                                       Okinawa\n",
+       "23                                  Grand Rapids\n",
+       "24                                  Northwest Uk\n",
+       "25                                    Central Pa\n",
+       "26                                      Campinas\n",
+       "27                                   Bhubaneswar\n",
+       "28                                          Lima\n",
+       "29                                      Arequipa\n",
+       "                         ...                    \n",
+       "36                                    Santa Cruz\n",
+       "37                                        Sydney\n",
+       "38                                      São Luís\n",
+       "39                                Salt Lake City\n",
+       "40                                     Amsterdam\n",
+       "41                                       Goiânia\n",
+       "42                                           Goa\n",
+       "43                                       Bangkok\n",
+       "44                                        Dublin\n",
+       "45                                        Recife\n",
+       "46                                       Houston\n",
+       "47                                        Recife\n",
+       "48                                         Paris\n",
+       "49                                     São Paulo\n",
+       "50                                       Kampala\n",
+       "51    Rural Federal University Of Rio De Janeiro\n",
+       "52                                      Teresina\n",
+       "53                                       Paraiba\n",
+       "54                                        Maceió\n",
+       "55                                        Recife\n",
+       "56                                         Belém\n",
+       "57                                        Madrid\n",
+       "58                                         Natal\n",
+       "59                                    São Carlos\n",
+       "60                                     Vancouver\n",
+       "61                                        Manaus\n",
+       "62                                        Brazil\n",
+       "63                                         Natal\n",
+       "64                                 New York City\n",
+       "65                                        Madrid\n",
+       "Name: name, Length: 66, dtype: object"
+      ]
+     },
+     "execution_count": 447,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.name = df.name.apply(standardize_chapter_name)\n",
+    "print(df.shape)\n",
+    "df.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 448,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>country</th>\n",
+       "      <th>subcountry</th>\n",
+       "      <th>geonameid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>les Escaldes</td>\n",
+       "      <td>Andorra</td>\n",
+       "      <td>Escaldes-Engordany</td>\n",
+       "      <td>3040051</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Andorra la Vella</td>\n",
+       "      <td>Andorra</td>\n",
+       "      <td>Andorra la Vella</td>\n",
+       "      <td>3041563</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Umm al Qaywayn</td>\n",
+       "      <td>United Arab Emirates</td>\n",
+       "      <td>Umm al Qaywayn</td>\n",
+       "      <td>290594</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Ras al-Khaimah</td>\n",
+       "      <td>United Arab Emirates</td>\n",
+       "      <td>Raʼs al Khaymah</td>\n",
+       "      <td>291074</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Khawr Fakkān</td>\n",
+       "      <td>United Arab Emirates</td>\n",
+       "      <td>Ash Shāriqah</td>\n",
+       "      <td>291696</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               name               country          subcountry  geonameid\n",
+       "0      les Escaldes               Andorra  Escaldes-Engordany    3040051\n",
+       "1  Andorra la Vella               Andorra    Andorra la Vella    3041563\n",
+       "2    Umm al Qaywayn  United Arab Emirates      Umm al Qaywayn     290594\n",
+       "3    Ras al-Khaimah  United Arab Emirates     Raʼs al Khaymah     291074\n",
+       "4      Khawr Fakkān  United Arab Emirates        Ash Shāriqah     291696"
+      ]
+     },
+     "execution_count": 448,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "package = Package('https://datahub.io/core/world-cities/datapackage.json')\n",
+    "\n",
+    "data_url = 'https://datahub.io/core/world-cities/datapackage.json'\n",
+    "\n",
+    "package = datapackage.Package(data_url)\n",
+    "\n",
+    "worldcities_df = None\n",
+    "\n",
+    "resources = package.resources\n",
+    "for resource in resources:\n",
+    "    if resource.tabular:\n",
+    "        worldcities_df = pd.read_csv(resource.descriptor['path'])\n",
+    "\n",
+    "worldcities_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 449,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(100, 9)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "timestampe                                 8/14/2019 20:37:25\n",
+       "name                                                 Brisbane\n",
+       "last_event                                           8/9/2019\n",
+       "challenges                                    Engaging people\n",
+       "improvement                  Advertising the PyLadies groups \n",
+       "intended_individual_email                                 NaN\n",
+       "intended_chapter_email                  brisbane@pyladies.com\n",
+       "country                                             Australia\n",
+       "subcountry                                         Queensland\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 449,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with_countries_df = pd.merge(df,\n",
+    "                             worldcities_df[['name', 'country', 'subcountry']],\n",
+    "                             on='name',\n",
+    "                             how='left')\n",
+    "\n",
+    "print(with_countries_df.shape)\n",
+    "with_countries_df.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 450,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with_countries_df['duplicated'] = with_countries_df['timestampe'].duplicated()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 451,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "52\n",
+      "             name         country\n",
+      "4          London          Canada\n",
+      "5          London  United Kingdom\n",
+      "6          London          Canada\n",
+      "7          London  United Kingdom\n",
+      "11  San Francisco       Argentina\n",
+      "12  San Francisco      Costa Rica\n",
+      "13  San Francisco     Philippines\n",
+      "14  San Francisco     Philippines\n",
+      "15  San Francisco     El Salvador\n",
+      "16  San Francisco   United States\n",
+      "17         London          Canada\n",
+      "18         London  United Kingdom\n",
+      "19      Vancouver          Canada\n",
+      "20      Vancouver   United States\n",
+      "22         La Paz       Argentina\n",
+      "23         La Paz         Bolivia\n",
+      "24         La Paz        Honduras\n",
+      "25         La Paz          Mexico\n",
+      "26         La Paz     Philippines\n",
+      "27         La Paz         Uruguay\n",
+      "30      Melbourne       Australia\n",
+      "31      Melbourne   United States\n",
+      "35         Newark   United States\n",
+      "36         Newark   United States\n",
+      "37         Newark   United States\n",
+      "38         Newark   United States\n",
+      "44       Campinas          Brazil\n",
+      "45       Campinas          Brazil\n",
+      "47           Lima            Peru\n",
+      "48           Lima   United States\n",
+      "56     Santa Cruz          Brazil\n",
+      "57     Santa Cruz           Chile\n",
+      "58     Santa Cruz     Philippines\n",
+      "59     Santa Cruz     Philippines\n",
+      "60     Santa Cruz     Philippines\n",
+      "61     Santa Cruz   United States\n",
+      "62         Sydney       Australia\n",
+      "63         Sydney          Canada\n",
+      "66      Amsterdam     Netherlands\n",
+      "67      Amsterdam   United States\n",
+      "71         Dublin         Ireland\n",
+      "72         Dublin   United States\n",
+      "73         Dublin   United States\n",
+      "74         Dublin   United States\n",
+      "86          Belém          Brazil\n",
+      "87          Belém          Brazil\n",
+      "88         Madrid        Colombia\n",
+      "89         Madrid           Spain\n",
+      "92      Vancouver          Canada\n",
+      "93      Vancouver   United States\n",
+      "98         Madrid        Colombia\n",
+      "99         Madrid           Spain\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get list of duplicated emails, and find the rows with these duplicated emails\n",
+    "duplicated_names = with_countries_df[with_countries_df['duplicated'] == True].intended_chapter_email.unique()\n",
+    "duplicated_rows = with_countries_df[with_countries_df.intended_chapter_email.isin(duplicated_names)]\n",
+    "\n",
+    "# Print this duplicated set of rows\n",
+    "print(len(duplicated_rows))\n",
+    "print(duplicated_rows[['name', 'country']])  # 'intended_chapter_email'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Validate which are incorrectly paired with a country\n",
+    "\n",
+    "* London, UK: \n",
+    "   - [MeetUp Organizers](https://www.meetup.com/PyLadiesLondon/members/?op=leaders)\n",
+    "      - Correct rows with IDs: 5, 7, 18\n",
+    "      - Drop IDs: 4, 6, 17\n",
+    "* San Francisco, USA:\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in USA \n",
+    "      - Correct rows with IDs: 16\n",
+    "      - Drop IDs: 11, 12, 13, 14, 15\n",
+    "* Vancouver, Canada:\n",
+    "   - [MeetUp Organizers](https://www.meetup.com/PyLadies-Vancouver/members/?op=leaders)\n",
+    "     - Correct rows with IDs: 19, 92\n",
+    "     - Drop IDs: 20, 93 \n",
+    "* La Paz, Bolivia:\n",
+    "  - [MeetUp Organizers](https://www.meetup.com/La-Paz-PyLadies-Meetup/members/?op=leaders)\n",
+    "     - Correct rows: 23\n",
+    "     - Drop IDS: 22, 24, 25, 26, 27\n",
+    "* Melbourne, Australia\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Australia \n",
+    "    - Correct rows: 30\n",
+    "    - Drop IDs: 31\n",
+    "* Newark, Delware\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in USA \n",
+    "    - Correct rows: 35\n",
+    "    - Drop IDs: 36, 37, 38\n",
+    "* Campinas, Brasil:\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Brasil \n",
+    "    - Correct rows: 44\n",
+    "    - Drop IDs: 45 \n",
+    "* Lima, Peru:\n",
+    "  - [PyLadies Lima writeup](https://medium.com/@karen_dax/1er-meetup-de-pyladies-lima-1214988ea711) \n",
+    "    - Correct rows: 47\n",
+    "    - Drop IDs: 48  \n",
+    "* Santa Cruz, USA:\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in USA \n",
+    "      - Correct rows with IDs: 61\n",
+    "      - Drop IDs: 56, 57, 58, 59, 60\n",
+    "* Sydney, Australia:\n",
+    "  - [MeetUp Organizers](https://www.meetup.com/en-AU/Sydney-PyLadies/members/?op=leaders)\n",
+    "     - Correct rows: 62\n",
+    "     - Drop IDS: 63\n",
+    "* Amsterdam, Netherleands:\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Netherlands\n",
+    "    - Correct rows: 66\n",
+    "    - Drop IDs: 67\n",
+    "* Dublin, Ireland\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Ireland \n",
+    "    - Correct rows: 71\n",
+    "    - Drop IDs: 72, 73, 74 \n",
+    "* Belem, Brasil\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Brasil \n",
+    "    - Correct rows: 86\n",
+    "    - Drop IDs: 87  \n",
+    "* Madrid, Spain\n",
+    "  - [Pyladies Chapters](https://www.pyladies.com/locations/) only has one location in Spain (found on MeetUp); [MeetUp Organizers](https://www.meetup.com/es-ES/PyLadiesMadrid/)\n",
+    "    - Correct rows: 89, 99\n",
+    "    - Drop IDs: 88, 98\n",
+    "\n",
+    "\n",
+    "correct_ids = [5, 7, 18, 16, 19, 92, 23, 30, 35, 44, 47, 61, 62, 66, 71, 86, 89, 99]\n",
+    "drop_ids = [4, 6, 17, 11, 12, 13, 14, 15, 20, 93, 22, 24, 25, 26, 27, 31, 36, 37, 38, 45, 48, 56, 57, 58, 59, 60, 63, 67, 72, 73, 74, 87, 88, 98]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 453,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Are the sizes of the two dataframes equal: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "correct_ids = [5, 7, 18, 16, 19, 92, 23, 30, 35, 44, 47, 61, 62, 66, 71, 86, 89, 99]\n",
+    "drop_ids = [4, 6, 17, 11, 12, 13, 14, 15, 20, 93, 22, 24, 25, 26, 27, 31, 36, 37, 38, 45, 48, 56, 57, 58, 59, 60, 63, 67, 72, 73, 74, 87, 88, 98]\n",
+    "\n",
+    "values_equal = with_countries_df.shape[0] - (len(drop_ids)) == df.shape[0]\n",
+    "# print(with_countries_df.shape[0] - (len(drop_ids)), df.shape[0])\n",
+    "# print(set(duplicated_rows.index) - set(drop_ids + correct_ids))\n",
+    "\n",
+    "print(f'Are the sizes of the two dataframes equal: {values_equal}')\n",
+    "\n",
+    "with_countries_df = with_countries_df.drop(drop_ids)\n",
+    "with_countries_df = with_countries_df.drop(columns=['duplicated'])\n",
+    "\n",
+    "# print(with_countries_df.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 454,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_country_to_contient(country):\n",
+    "    if not isinstance(country, str):\n",
+    "        return 'N/A'\n",
+    "    country_code = pc.country_name_to_country_alpha2(country, cn_name_format=\"default\")\n",
+    "    return pc.country_alpha2_to_continent_code(country_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 455,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with_countries_df['continent_code'] = with_countries_df.country.apply(convert_country_to_contient)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 456,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13 are unidentified.\n",
+      "1                                        Nigeria\n",
+      "9                                       Brasilia\n",
+      "32                                       Effurun\n",
+      "42                                  Northwest Uk\n",
+      "43                                    Central Pa\n",
+      "46                                   Bhubaneswar\n",
+      "51                                         Ghana\n",
+      "52                                   Pyladiesrgv\n",
+      "53                                           Rdu\n",
+      "55                                Rio De Janeiro\n",
+      "81    Rural Federal University Of Rio De Janeiro\n",
+      "83                                       Paraiba\n",
+      "95                                        Brazil\n",
+      "Name: name, dtype: object\n"
+     ]
+    }
+   ],
+   "source": [
+    "na_continent = with_countries_df[with_countries_df.continent_code == 'N/A']\n",
+    "print(f'{len(na_continent)} are unidentified.')\n",
+    "print(na_continent.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 457,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with_countries_df.at[1, 'country'] = 'Nigeria'\n",
+    "with_countries_df.at[9, 'country'] = 'Brazil'\n",
+    "with_countries_df.at[32, 'country'] = 'Nigeria'\n",
+    "with_countries_df.at[42, 'country'] = 'United Kingdom'\n",
+    "with_countries_df.at[43, 'country'] = 'United States'\n",
+    "with_countries_df.at[46, 'country'] = 'India'\n",
+    "with_countries_df.at[51, 'country'] = 'Ghana'\n",
+    "with_countries_df.at[52, 'country'] = 'United States'   # https://twitter.com/pyladiesrgv\n",
+    "with_countries_df.at[53, 'country'] = 'United States'   # https://www.meetup.com/pyladies-rdu/\n",
+    "with_countries_df.at[55, 'country'] = 'Brazil'\n",
+    "with_countries_df.at[81, 'country'] = 'Brazil'\n",
+    "with_countries_df.at[83, 'country'] = 'Brazil'\n",
+    "with_countries_df.at[95, 'country'] = 'Brazil'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 458,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with_countries_df['continent_code'] = with_countries_df.country.apply(convert_country_to_contient)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 459,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 459,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "na_continent = with_countries_df[with_countries_df.continent_code == 'N/A']\n",
+    "na_continent.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 436,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "export_csv = with_countries_df.to_csv('pyladies_chapters_survey_with_country_info.csv', index = None, header=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 469,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of unique chapter responses: 59\n",
+      "Here are the chapters: ['Brisbane' 'Nigeria' 'Hamburg' 'Wellesley' 'London' 'Miami' 'Brasilia'\n",
+      " 'Addis Ababa' 'San Francisco' 'Vancouver' 'Oakland' 'La Paz' 'Seattle'\n",
+      " 'Fortaleza' 'Melbourne' 'Effurun' 'Chicago' 'Chennai' 'Newark'\n",
+      " 'Mexico City' 'Okinawa' 'Grand Rapids' 'Northwest Uk' 'Central Pa'\n",
+      " 'Campinas' 'Bhubaneswar' 'Lima' 'Arequipa' 'Doboj' 'Ghana' 'Pyladiesrgv'\n",
+      " 'Rdu' 'Berlin' 'Rio De Janeiro' 'Santa Cruz' 'Sydney' 'São Luís'\n",
+      " 'Salt Lake City' 'Amsterdam' 'Goiânia' 'Goa' 'Bangkok' 'Dublin' 'Recife'\n",
+      " 'Houston' 'Paris' 'São Paulo' 'Kampala'\n",
+      " 'Rural Federal University Of Rio De Janeiro' 'Teresina' 'Paraiba'\n",
+      " 'Maceió' 'Belém' 'Madrid' 'Natal' 'São Carlos' 'Manaus' 'Brazil'\n",
+      " 'New York City']\n"
+     ]
+    }
+   ],
+   "source": [
+    "unique_chapters = with_countries_df.name.unique()\n",
+    "print(f'Number of unique chapter responses: {len(unique_chapters)}')\n",
+    "print(f'Here are the chapters: {unique_chapters}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 471,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "22"
+      ]
+     },
+     "execution_count": 471,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uniquewith_countries_df.country.unique())\n",
+    "print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Overview

This notebook starts digging into the feedback for the 2019 chapter organizer survey and to provide analysis on it #25.

In the notebook the responses (found in the PyLadies shared organizer folder for those with @pyladies.com email addresses) are normalized to help us identify the number of unique chapter responses and that data is joined with world cities data to determine overall number of countries responding.

## Future work 

Work to be done after this:

- Analyze text of things that need help
- Demonstrate how many chapters active within last 3 months, 6 months, 1 year