### PR TITLE
Update slack_etiquette.md to include note on slack messages not being deletable.

### DIFF
--- a/process/slack_etiquette.md
+++ b/process/slack_etiquette.md
@@ -39,6 +39,10 @@ Questions in #general tend to get answered quickly, or they get pushed off the s
 Conversely, if a channel is particularly quiet, please do not post "this channel is quiet".  Instead, try posting a question/article/or discussion point that others in the channel might comment on or enjoy.
 
 
+### :star2: Messages in Slack cannot be deleted
+
+We allow users to edit their messages for a short period of time after posting, ie to fix typos. But we keep messages as *proof*, for when people post inappropriate content.
+
 
 ### :star2: Don’t “ask to ask”
 Newcomers very commonly ask about asking a question in one of a few ways:

--- a/process/slack_etiquette.md
+++ b/process/slack_etiquette.md
@@ -41,7 +41,7 @@ Conversely, if a channel is particularly quiet, please do not post "this channel
 
 ### :star2: Messages in Slack cannot be deleted
 
-We allow users to edit their messages for a short period of time after posting, ie to fix typos. But we keep messages as *proof*, for when people post inappropriate content.
+We allow users to edit their messages for a short period of time after posting, i.e. to fix typos. We store messages as *historical records*; so please refrain from posting inappropriate content.
 
 
 ### :star2: Don’t “ask to ask”


### PR DESCRIPTION
As per the [conversation](https://pyladies.slack.com/archives/C1F9A0K7F/p1707313118839909?thread_ts=1707312870.081709&cid=C1F9A0K7F) in the organiser's slack channel, I (@sleepypioneer) on behalf of the PyLadies community am proposing this update :) 